### PR TITLE
Add Windows-specific winapi dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,6 +2495,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ rfd = { version = "0.12", default-features = false, features = ["xdg-portal"] }
 [target.'cfg(target_env = "musl")'.dependencies]
 mimalloc = "0.1.43"
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3.9", features = ["winuser"] }
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"


### PR DESCRIPTION
## Summary
- add a Windows-only dependency on winapi with the winuser feature to ensure the GUI builds on that platform
- update the lockfile so the new platform-specific dependency is tracked

## Testing
- cargo build --release --target x86_64-pc-windows-msvc *(fails: target `x86_64-pc-windows-msvc` is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d07c6541f08328be06d004b664b029