### PR TITLE
Enable default fonts for eframe GUI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ either = "1"
 memmap2 = "0.9.5"
 rawzip = "0.4.1"
 libdeflater = "1.23.0"
-eframe = { version = "0.24", default-features = false, features = ["glow"] }
+eframe = { version = "0.24", default-features = false, features = ["default_fonts", "glow"] }
 rfd = { version = "0.12", default-features = false, features = ["xdg-portal"] }
 
 [target.'cfg(target_env = "musl")'.dependencies]


### PR DESCRIPTION
## Summary
- enable the default_fonts feature for the eframe dependency so the GUI includes the bundled fonts

## Testing
- cargo run --bin rrrocket_gui *(fails: missing libXcursor.so.1 in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d07fefa4688328a0467406f55fb919